### PR TITLE
Fix clear client policy command for loop, reset model filters

### DIFF
--- a/src/main/java/seedu/siasa/logic/commands/client/ClearClientPolicyCommand.java
+++ b/src/main/java/seedu/siasa/logic/commands/client/ClearClientPolicyCommand.java
@@ -50,11 +50,16 @@ public class ClearClientPolicyCommand extends Command {
         model.updateFilteredPolicyList(new PolicyIsOwnedByPredicate(owner));
 
         List<Policy> policyList = model.getFilteredPolicyList();
+
         int deletedPolicies = policyList.size();
 
-        for (Policy policy : policyList) {
-            model.deletePolicy(policy);
+        for (int i = deletedPolicies - 1; i >= 0; i--) {
+            Policy toDelete = policyList.get(i);
+            model.deletePolicy(toDelete);
         }
+
+        // Remove filter to display policies correctly in UI
+        model.updateFilteredPolicyList(x -> true);
 
         return new CommandResult(
                 String.format(MESSAGE_CLEAR_CLIENT_POLICY_SUCCESS,

--- a/src/main/java/seedu/siasa/logic/commands/client/ClearClientPolicyCommand.java
+++ b/src/main/java/seedu/siasa/logic/commands/client/ClearClientPolicyCommand.java
@@ -27,7 +27,7 @@ public class ClearClientPolicyCommand extends Command {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_CLEAR_CLIENT_POLICY_SUCCESS = "Deleted %1$s policies belonging to client %1$s";
+    public static final String MESSAGE_CLEAR_CLIENT_POLICY_SUCCESS = "Deleted %1$s policies belonging to client %2$s";
 
     private final Index targetIndex;
 
@@ -46,17 +46,11 @@ public class ClearClientPolicyCommand extends Command {
         }
 
         Person owner = lastShownList.get(targetIndex.getZeroBased());
-
         model.updateFilteredPolicyList(new PolicyIsOwnedByPredicate(owner));
-
         List<Policy> policyList = model.getFilteredPolicyList();
-
         int deletedPolicies = policyList.size();
 
-        for (int i = deletedPolicies - 1; i >= 0; i--) {
-            Policy toDelete = policyList.get(i);
-            model.deletePolicy(toDelete);
-        }
+        model.removePoliciesBelongingTo(owner);
 
         // Remove filter to display policies correctly in UI
         model.updateFilteredPolicyList(x -> true);

--- a/src/main/java/seedu/siasa/model/Model.java
+++ b/src/main/java/seedu/siasa/model/Model.java
@@ -111,6 +111,12 @@ public interface Model {
      */
     void setPolicy(Policy target, Policy editedPolicy);
 
+    /**
+     * Removes all policies belonging to the given person {@code target}.
+     * {@code target} must exist in the SIASA.
+     */
+    void removePoliciesBelongingTo(Person target);
+
     /** Returns an unmodifiable view of the filtered policy list */
     ObservableList<Policy> getFilteredPolicyList();
 

--- a/src/main/java/seedu/siasa/model/ModelManager.java
+++ b/src/main/java/seedu/siasa/model/ModelManager.java
@@ -143,6 +143,11 @@ public class ModelManager implements Model {
         siasa.setPolicy(target, editedPolicy);
     }
 
+    @Override
+    public void removePoliciesBelongingTo(Person target) {
+        siasa.removePoliciesBelongingTo(target);
+    }
+
     //=========== Filtered Person List Accessors =============================================================
 
     /**

--- a/src/main/java/seedu/siasa/model/Siasa.java
+++ b/src/main/java/seedu/siasa/model/Siasa.java
@@ -102,6 +102,14 @@ public class Siasa implements ReadOnlySiasa {
     }
 
     /**
+     * Removes all policies associated with {@code key}.
+     * {@code key} must exist in SIASA.
+     */
+    public void removePoliciesBelongingTo(Person key) {
+        policies.removeBelongingTo(key);
+    }
+
+    /**
      * Returns true if a policy with the same identity as {@code policy} exists in SIASA.
      */
     public boolean hasPolicy(Policy policy) {

--- a/src/main/java/seedu/siasa/model/policy/UniquePolicyList.java
+++ b/src/main/java/seedu/siasa/model/policy/UniquePolicyList.java
@@ -74,7 +74,8 @@ public class UniquePolicyList implements Iterable<Policy> {
      */
     public void removeBelongingTo(Person owner) {
         requireNonNull(owner);
-        for (Policy policy: internalList) {
+        for (int i = internalList.size() - 1; i >= 0; i--) {
+            Policy policy = internalList.get(i);
             if (policy.getOwner().equals(owner)) {
                 remove(policy);
             }

--- a/src/test/java/seedu/siasa/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/siasa/logic/commands/AddCommandTest.java
@@ -170,6 +170,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void removePoliciesBelongingTo(Person target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Policy> getFilteredPolicyList() {
             throw new AssertionError("This method should not be called.");
         }


### PR DESCRIPTION
Fix for loop to delete all policies. Remove model filters at the end of execute() so UI displays policies correctly.